### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
     cmx_js:
         image: ghcr.io/jehy/cmx.js:master


### PR DESCRIPTION
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion